### PR TITLE
yum executable renamed to yum-deprecated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install:
 	$(PYTHON) -c "import compileall; compileall.compile_dir('$(DESTDIR)/usr/share/yum-cli', 1, '/usr/share/yum-cli', 1)"
 
 	mkdir -p $(DESTDIR)/usr/bin $(DESTDIR)/usr/sbin
-	install -m 755 bin/yum.py $(DESTDIR)/usr/bin/yum
+	install -m 755 bin/yum.py $(DESTDIR)/usr/bin/yum-deprecated
 	install -m 755 bin/yum-updatesd.py $(DESTDIR)/usr/sbin/yum-updatesd
 
 	mkdir -p $(DESTDIR)/var/cache/yum

--- a/bin/yum.py
+++ b/bin/yum.py
@@ -1,5 +1,11 @@
 #!/usr/bin/python
 import sys
+
+sys.stderr.write("""\
+Yum command has been deprecated, use dnf instead.
+See 'man dnf' and 'man yum2dnf' for more information.\n
+""")
+
 try:
     import yum
 except ImportError:

--- a/yum.spec
+++ b/yum.spec
@@ -63,7 +63,7 @@ BuildRequires: bash-completion
 
 Summary: RPM package installer/updater/manager
 Name: yum
-Version: 3.4.3
+Version: 3.4.4
 Release: 0
 License: GPLv2+
 Group: System Environment/Base
@@ -429,7 +429,7 @@ exit 0
 %if %{yum_updatesd}
 %exclude %{_datadir}/yum-cli/yumupd.py*
 %endif
-%{_bindir}/yum
+%{_bindir}/yum-deprecated
 %{python_sitelib}/yum
 %{python_sitelib}/rpmUtils
 %dir /var/cache/yum


### PR DESCRIPTION
This is based on Fesco ticket [1].
Discussed with Valentina and DNF team. Any oppinions on raising minor version for f22?
cc @rholy @MichaelMraka @james-antill @mluscon
[1] https://fedorahosted.org/fesco/ticket/1312#comment:29
