### PR TITLE
Don't crash on invalid repoid from yumdb

### DIFF
--- a/docs/yum.8
+++ b/docs/yum.8
@@ -964,6 +964,8 @@ The format of the output of yum list is:
 
 name.arch [epoch:]version-release  repo or @installed-from-repo
 
+Note that if the repo cannot be determined, "installed" is printed instead.
+
 .IP "\fByum list [all | glob_exp1] [glob_exp2] [\&.\&.\&.]\fP"
 List all available and installed packages\&.
 .IP "\fByum list available [glob_exp1] [\&.\&.\&.]\fP"

--- a/yum/__init__.py
+++ b/yum/__init__.py
@@ -95,7 +95,6 @@ from yum.rpmtrans import RPMTransaction,SimpleCliCallBack
 from yum.i18n import to_unicode, to_str, exception2msg
 from yum.drpm import DeltaInfo, DeltaPackage
 
-import string
 import StringIO
 
 from weakref import proxy as weakref
@@ -476,17 +475,7 @@ class YumBase(depsolve.Depsolve):
                 continue
 
             # Check the repo.id against the valid chars
-            bad = None
-            for byte in section:
-                if byte in string.ascii_letters:
-                    continue
-                if byte in string.digits:
-                    continue
-                if byte in "-_.:":
-                    continue
-                
-                bad = byte
-                break
+            bad = misc.validate_repoid(section)
 
             if bad:
                 self.logger.warning("Bad id for repo: %s, byte = %s %d" %

--- a/yum/misc.py
+++ b/yum/misc.py
@@ -24,6 +24,7 @@ import bz2
 import gzip
 import shutil
 import urllib
+import string
 _available_compression = ['gz', 'bz2']
 try:
     import lzma
@@ -1248,3 +1249,12 @@ def filter_pkgs_repoid(pkgs, repoid):
             continue
         ret.append(pkg)
     return ret
+
+def validate_repoid(repoid):
+    """Return the first invalid char found in the repoid, or None."""
+    allowed_chars = string.ascii_letters + string.digits + '-_.:'
+    for char in repoid:
+        if char not in allowed_chars:
+            return char
+    else:
+        return None

--- a/yum/rpmsack.py
+++ b/yum/rpmsack.py
@@ -1755,6 +1755,9 @@ class RPMDBAdditionalDataPackage(object):
                                 'group_member',
                                 'command_line'])
 
+    # Validate these attributes when they are read from a file
+    _validators = {}
+
     def __init__(self, conf, pkgdir, yumdb_cache=None):
         self._conf = conf
         self._mydir = pkgdir
@@ -1902,6 +1905,15 @@ class RPMDBAdditionalDataPackage(object):
         value = fo.read()
         fo.close()
         del fo
+
+        # Validate the attribute we just read from the file.  Some attributes
+        # may require being in a specific format and we can't guarantee the
+        # file has not been tampered with outside of yum.
+        if attr in self._validators:
+            valid = self._validators[attr]
+            if not valid(value):
+                raise AttributeError, \
+                    "Invalid value of attribute %s on %s" % (attr, self)
 
         if info.st_nlink > 1 and self._yumdb_cache is not None:
             self._yumdb_cache[key] = value

--- a/yum/rpmsack.py
+++ b/yum/rpmsack.py
@@ -1756,7 +1756,10 @@ class RPMDBAdditionalDataPackage(object):
                                 'command_line'])
 
     # Validate these attributes when they are read from a file
-    _validators = {}
+    _validators = {
+        # Fixes BZ 1234967
+        'from_repo': lambda repoid: misc.validate_repoid(repoid) is None,
+    }
 
     def __init__(self, conf, pkgdir, yumdb_cache=None):
         self._conf = conf


### PR DESCRIPTION
Ensure the ui_from_repo property always returns ascii-only strings.

Previously, if the yumdb had been tampered with and a repoid was
corrupted for some reason so that it contained non-ascii chars, we could
end up reading it and then crash on an implicit conversion to unicode,
e.g. in output.fmtColumns().

We could also explicitly convert the data passed to fmtColumns() but
that may not fix this completely as we couldn't guarantee that, with the
same corrupted repoid, such an implicit conversion wouldn't happen
elsewhere.  Likewise, doing the conversion in ui_from_repo and returning
a unicode string may cause an implicit conversion elsewhere.
