### PR TITLE
updateinfo: accept respin in advisory name. BZ 1065380

### DIFF
--- a/yum/misc.py
+++ b/yum/misc.py
@@ -1258,3 +1258,18 @@ def validate_repoid(repoid):
             return char
     else:
         return None
+
+def split_advisory(id_):
+    """Split the advisory ID into the root ID and respin suffix."""
+
+    # Regexes for different advisory formats
+    patterns = [
+        r'^(RH[BES]A\-\d+\:\d+)(?:\-(\d+))?$',  # Red Hat errata
+    ]
+
+    for pat in patterns:
+        match = re.match(pat, id_)
+        if match:
+            return match.groups()
+    else:
+        return id_, None

--- a/yumcommands.py
+++ b/yumcommands.py
@@ -4098,7 +4098,6 @@ class UpdateinfoCommand(YumCommand):
             # or -q deletes everything.
             print x
 
-        opts = _upi._updateinfofilter2opts(base.updateinfo_filters)
         extcmds, show_type, filt_type = self._parse_extcmds(extcmds)
 
         list_type = "updates"
@@ -4107,7 +4106,7 @@ class UpdateinfoCommand(YumCommand):
             if filt_type is None:
                 extcmds, show_type, filt_type = self._parse_extcmds(extcmds)
 
-        opts.sec_cmds = extcmds
+        opts = _upi._ysp_gen_opts(base.updateinfo_filters, md_info, extcmds)
         used_map = _upi._ysp_gen_used_map(base.updateinfo_filters)
         iname2tup = {}
         if False: pass


### PR DESCRIPTION
When addressing Red Hat errata, we don't expect nor want the users to
care about respin numbers.  Still, in some places like the RHN portal,
we do display them in the form of an advisory name suffix.  Since the
updateinfo data usually doesn't include them either, we currently return
no matches if the user specifies such an extended form on the cmdline
(e.g. by copy-pasting it from the RHN portal).

This commit addresses that by either interpreting such an advisory name
exactly as specified or, if that would yield zero matches, taking it as
if the respin suffix was omitted.  This applies to all such places where
advisory names are expected on the cmdline.

Examples of new behavior:

```
# updateinfo only contains RHSA-2016:1234 (typical scenario)
yum updateinfo RHSA-2014:1234-3  # matches RHSA-2016:1234
yum updateinfo RHSA-2014:1234    # matches RHSA-2016:1234

# updateinfo also contains RHSA-2016:1234-3
yum updateinfo RHSA-2014:1234-3  # matches RHSA-2016:1234-3 (only)
yum updateinfo RHSA-2014:1234    # matches RHSA-2016:1234 (only)
```
