### PR TITLE
Make YumHistoryRpmdbProblem objects hashable. BZ 1292087

### DIFF
--- a/yum/history.py
+++ b/yum/history.py
@@ -244,6 +244,9 @@ class YumHistoryRpmdbProblem:
         ret = cmp(self.rpid, other.rpid)
         return ret
 
+    def __hash__(self):
+        return hash(self.rpid)
+
     def _getProbPkgs(self):
         if self._loaded_P is None:
             self._loaded_P = sorted(self._history._old_prob_pkgs(self.rpid))


### PR DESCRIPTION
Let's use rpid for that to ensure we get the same hash value for objects
that compare equal (which is iff their rpid's match, see **cmp**).
