### PR TITLE
comps.rng: ignore ordering in comps element

### DIFF
--- a/docs/comps.rng
+++ b/docs/comps.rng
@@ -17,16 +17,16 @@
   </start>
   <define name="comps">
     <element name="comps">
-      <oneOrMore>
-        <ref name="group"/>
-      </oneOrMore>
-      <zeroOrMore>
-        <ref name="environment"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="category"/>
-      </zeroOrMore>
       <interleave><!-- We don't care what order these are in -->
+        <oneOrMore>
+          <ref name="group"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="environment"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="category"/>
+        </zeroOrMore>
         <optional>
           <ref name="whiteout"/>
         </optional>


### PR DESCRIPTION
We allow comps child elements to occur in any order when parsing comps
files, so make the RNG schema reflect that, too.
