### PR TITLE
Report __del__ RepoError exceptions into log instead of stderr (#1356797)

### DIFF
--- a/yum/__init__.py
+++ b/yum/__init__.py
@@ -234,11 +234,14 @@ class YumBase(depsolve.Depsolve):
         self.updateinfo_filters = {}
 
     def __del__(self):
-        self.close()
-        self.closeRpmDB()
-        self.doUnlock()
-        # call cleanup callbacks
-        for cb in self._cleanup: cb()
+        try:
+            self.close()
+            self.closeRpmDB()
+            self.doUnlock()
+            # call cleanup callbacks
+            for cb in self._cleanup: cb()
+        except Errors.RepoError, e:
+            self.verbose_logger.debug("Exception %s %s in %s ignored" % (repr(e), str(e), self.__del__))
 
     def close(self):
         """Close the history and repo objects."""

--- a/yum/repos.py
+++ b/yum/repos.py
@@ -161,7 +161,10 @@ class RepoStorage:
         return str(self.repos.keys())
 
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except Errors.RepoError, e:
+            self.logger.debug("Exception %s %s in %s ignored" % (repr(e), str(e), self.__del__))
 
     def close(self):
         for repo in self.repos.values():
@@ -423,7 +426,10 @@ class Repository:
         return hash(self.id)
         
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except Errors.RepoError, e:
+            self.logger.debug("Exception %s %s in %s ignored" % (repr(e), str(e), self.__del__))
 
     def _ui_id(self):
         """ Show self.id, so we can use it and override it. """

--- a/yum/yumRepo.py
+++ b/yum/yumRepo.py
@@ -114,7 +114,10 @@ class YumPackageSack(packageSack.PackageSack):
         self.added = {}
 
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except Errors.RepoError, e:
+            verbose_logger.debug("Exception %s %s in %s ignored" % (repr(e), str(e), self.__del__))
 
     def close(self):
         self.added = {}


### PR DESCRIPTION
Report **del** RepoError exceptions into log instead of stderr (#1356797)

So it does not clutter text UI of clients like Anaconda.

Resolves: rhbz#1356797
