### PR TITLE
Fix for 'history package-list'

### DIFF
--- a/yum/history.py
+++ b/yum/history.py
@@ -1471,9 +1471,9 @@ class YumHistory:
         params = list(pkgtupids)
         tids = set()
         if len(params) > yum.constants.PATTERNS_INDEXED_MAX:
-            executeSQL(cur, """SELECT tid FROM trans_data_pkgs""")
+            executeSQL(cur, """SELECT tid,pkgtupid FROM trans_data_pkgs""")
             for row in cur:
-                if row[0] in params:
+                if row[1] in params:
                     tids.add(row[0])
             return tids
         if not params:


### PR DESCRIPTION
The 'yum history package-list package-name' fails to work when transactions for that package are greater than 128(PATTERNS_INDEXED_MAX). This fixes the SQL query.