### PR TITLE
Remove chop for `yum repolist`

### DIFF
--- a/yumcommands.py
+++ b/yumcommands.py
@@ -2397,15 +2397,14 @@ class RepoListCommand(YumCommand):
                 if arg == 'disabled': # Don't output a status column.
                     base.verbose_logger.info("%s %s",
                                             utf8_width_fill(rid, id_len),
-                                            utf8_width_fill(rname, nm_len,
-                                                            nm_len))
+                                            utf8_width_fill(rname, nm_len))
                     continue
 
                 if ui_num:
                     ui_num = utf8_width_fill(ui_num, ui_len, left=False)
                 base.verbose_logger.info("%s %s %s%s",
                                         utf8_width_fill(rid, id_len),
-                                        utf8_width_fill(rname, nm_len, nm_len),
+                                        utf8_width_fill(rname, nm_len),
                                         ui_enabled, ui_num)
 
         return 0, ['repolist: ' +to_unicode(locale.format("%d", tot_num, True))]


### PR DESCRIPTION
Remove chop for `yum repolist`. 

Before:
```
# strace -s 4096 -ewrite yum repolist > /dev/null
write(1, "!remi-safe                  Safe Remi's RPM repository for Enterprise       2005\n", 81) = 81
```

After:
```
write(1, "!remi-safe                  Safe Remi's RPM repository for Enterprise Linux 7 - x86_64      2005\n", 97) = 97
```

What this means, that you can't use `grep` for longer than 81 chars `repo name`. For instance:
```
# yum repolist | grep "Safe Remi's RPM repository for Enterprise Linux"
#
```