### PR TITLE
yum-cron: reintroduce days_of_week parameter

### DIFF
--- a/etc/yum-cron-hourly.conf
+++ b/etc/yum-cron-hourly.conf
@@ -20,6 +20,10 @@ download_updates = no
 # the update to be applied
 apply_updates = no
 
+# You may set days_of_week to the numeric days of the week you want to run,
+# where 0 is Sunday and 6 is Saturday. The default is to run every day.
+days_of_week = "0123456"
+
 # Maximum amout of time to randomly sleep, in minutes.  The program
 # will sleep for a random amount of time between 0 and random_sleep
 # minutes before running.  This is useful for e.g. staggering the

--- a/etc/yum-cron-hourly.conf
+++ b/etc/yum-cron-hourly.conf
@@ -21,7 +21,7 @@ download_updates = no
 apply_updates = no
 
 # You may set days_of_week to the numeric days of the week you want to run,
-# where 0 is Sunday and 6 is Saturday. The default is to run every day.
+# where 0 is Monday and 6 is Sunday. The default is to run every day.
 days_of_week = "0123456"
 
 # Maximum amout of time to randomly sleep, in minutes.  The program

--- a/etc/yum-cron-security.conf
+++ b/etc/yum-cron-security.conf
@@ -21,7 +21,7 @@ download_updates = yes
 apply_updates = yes
 
 # You may set days_of_week to the numeric days of the week you want to run,
-# where 0 is Sunday and 6 is Saturday. The default is to run every day.
+# where 0 is Monday and 6 is Sunday. The default is to run every day.
 days_of_week = "0123456"
 
 # Maximum amout of time to randomly sleep, in minutes.  The program

--- a/etc/yum-cron-security.conf
+++ b/etc/yum-cron-security.conf
@@ -20,6 +20,10 @@ download_updates = yes
 # the update to be applied
 apply_updates = yes
 
+# You may set days_of_week to the numeric days of the week you want to run,
+# where 0 is Sunday and 6 is Saturday. The default is to run every day.
+days_of_week = "0123456"
+
 # Maximum amout of time to randomly sleep, in minutes.  The program
 # will sleep for a random amount of time between 0 and random_sleep
 # minutes before running.  This is useful for e.g. staggering the

--- a/etc/yum-cron.conf
+++ b/etc/yum-cron.conf
@@ -19,6 +19,10 @@ download_updates = yes
 # that download_updates must also be yes for the update to be applied.
 apply_updates = no
 
+# You may set days_of_week to the numeric days of the week you want to run,
+# where 0 is Sunday and 6 is Saturday. The default is to run every day.
+days_of_week = "0123456"
+
 # Maximum amout of time to randomly sleep, in minutes.  The program
 # will sleep for a random amount of time between 0 and random_sleep
 # minutes before running.  This is useful for e.g. staggering the

--- a/yum-cron/yum-cron.py
+++ b/yum-cron/yum-cron.py
@@ -15,6 +15,7 @@ from yum.i18n import to_str, to_utf8, to_unicode, utf8_width, utf8_width_fill, u
 from yum import  _, P_
 import yum.updateinfo
 import smtplib
+import datetime
 from random import random
 from time import sleep
 from yum.misc import setup_locale
@@ -279,6 +280,7 @@ class YumCronConfig(BaseConfig):
     lock_sleep = IntOption(60)
     emit_via = ListOption(['email','stdio'])
     email_to = ListOption(["root"])
+    days_of_week = Option("0123456")
     email_from = Option("root")
     email_host = Option("localhost")
     email_port = IntOption(25)
@@ -307,6 +309,10 @@ class YumCronBase(yum.YumBase, YumOutput):
         self.readConfigFile(config_file_name)
         self.term.reinit(color='never')
         self.term.columns = self.opts.output_width
+
+        # Days of week
+        if str(datetime.datetime.today().weekday()) not in self.opts.days_of_week:
+            sys.exit(0)
 
 
         # Create the emitters, and add them to the list


### PR DESCRIPTION
In previous versions of yum_cron we had available to us the days_of_week parameter. This patch reintroduces that behavior, and adds the default days_of_week setting in the sample configuration files. 