### PR TITLE
Don't require enabled repos for URL installs. BZ 1175315

### DIFF
--- a/yumcommands.py
+++ b/yumcommands.py
@@ -253,7 +253,8 @@ def checkEnabledRepo(base, possible_local_files=[]):
         return
 
     for lfile in possible_local_files:
-        if lfile.endswith(".rpm") and os.path.exists(lfile):
+        if lfile.endswith(".rpm") and (yum.misc.re_remote_url(lfile) or
+                                       os.path.exists(lfile)):
             return
 
     # runs prereposetup (which "most" plugins currently use to add repos.)


### PR DESCRIPTION
This makes the check consistent with cli.py:installPkgs():979