### PR TITLE
Get loginuid in AIX platform

### DIFF
--- a/yum/misc.py
+++ b/yum/misc.py
@@ -25,6 +25,7 @@ import gzip
 import shutil
 import urllib
 import string
+import platform
 _available_compression = ['gz', 'bz2']
 try:
     import lzma
@@ -974,7 +975,10 @@ def _getloginuid():
     #  We might normally call audit.audit_getloginuid(), except that requires
     # importing all of the audit module. And it doesn't work anyway: BZ 518721
     try:
-        fo = open("/proc/self/loginuid")
+        if (platform.system() == "AIX"):
+            fo = os.popen('/usr/bin/id -l -u')
+        else:
+            fo = open("/proc/self/loginuid")
     except IOError:
         return None
     data = fo.read()


### PR DESCRIPTION
This PR is all about getting the loginuid in AIX platform. The mechanism in AIX is different from Linux. AIX has getuidx API (libc) through which one can get the loginuid. Python ctypes library loading has issues in AIX so directly invoking the API is not feasible right now. So AIX id command is used instead. Thanks @james-antill for pointing out the code which needs to be fixed. More info can be found from https://github.com/rpm-software-management/yum/issues/42