### PR TITLE
Don't pollute stderr in FIPS mode. BZ 1287610

### DIFF
--- a/yum/Errors.py
+++ b/yum/Errors.py
@@ -106,6 +106,11 @@ class ConfigError(YumBaseError):
 class MiscError(YumBaseError):
     pass
 
+class FIPSNonCompliantError(MiscError):
+    def __init__(self, sumtype):
+        MiscError.__init__(
+            self, '%s algorithm is not FIPS compliant' % sumtype)
+
 class GroupsError(YumBaseError):
     pass
 

--- a/yum/yumRepo.py
+++ b/yum/yumRepo.py
@@ -500,8 +500,10 @@ class YumRepository(Repository, config.RepoConf):
         except (Errors.MiscError, EnvironmentError), e:
             if checksum_can_fail:
                 return None
-            raise Errors.RepoError('Error opening file for checksum: %s' % e,
-                                   repo=self)
+            msg = 'Error opening file for checksum: %s' % e
+            if isinstance(e, Errors.FIPSNonCompliantError):
+                msg = str(e)
+            raise Errors.RepoError(msg, repo=self)
 
     def dump(self):
         output = '[%s]\n' % self.id
@@ -1805,7 +1807,7 @@ Insufficient space in download directory %s
         except Errors.RepoError, e:
             if check_can_fail:
                 return None
-            raise URLGrabError(-3, 'Error performing checksum')
+            raise URLGrabError(-3, 'Error performing checksum: %s' % e)
 
         if l_csum == r_csum:
             _xattr_set_chksum(file, r_ctype, l_csum)


### PR DESCRIPTION
When the system is in FIPS mode, certain unsecure checksum algorithms
such as md5 are disabled by hashlib and thus not available in yum.  We
normally print an error during misc.py initialization for every such
algorithm, however that's just too annoying if it happens on every yum
run and is also confusing (as it doesn't say why the particular
algorithm is disabled).

Let's stop printing the message if the cause is FIPS mode and also
extend the message that is printed when yum actually tries to use such a
checksum algorithm (e.g. during repodata verification of a repo using
md5) so that it says it's due to FIPS.

Note: Custom FIPSNonCompliantError(MiscError) class is used instead of
just MiscError so that we can make the resulting message shorter in
YumRepository._checksum() without changing the message for any other
exceptions handled in that method.