### PR TITLE
Fix from_repo yumdb validator for local pkgs

### DIFF
--- a/yum/rpmsack.py
+++ b/yum/rpmsack.py
@@ -1748,6 +1748,12 @@ class RPMDBAdditionalData(object):
 
         pass
 
+def _validate_from_repo(value):
+    if value and value[0] == '/':
+        # Local package; chop the slash as it's not a valid repoid char
+        value = value[1:]
+    return misc.validate_repoid(value) is None
+
 class RPMDBAdditionalDataPackage(object):
 
     # We do auto hardlink on these attributes
@@ -1761,7 +1767,7 @@ class RPMDBAdditionalDataPackage(object):
     # Validate these attributes when they are read from a file
     _validators = {
         # Fixes BZ 1234967
-        'from_repo': lambda repoid: misc.validate_repoid(repoid) is None,
+        'from_repo': _validate_from_repo,
     }
 
     def __init__(self, conf, pkgdir, yumdb_cache=None):


### PR DESCRIPTION
When making commit 6972a280, I didn't take into account locally
installed packages that have /filename as their repoid (which gets
written to yumdb as from_repo).  As a result, yum would print
"installed" (instead of the correct '@/foo-1.2-3') as the repo for the
package foo (e.g. when doing "yum list foo"), and would even crash when
doing "yumdb info foo".

Closes #49.

Kudos to James Antill for spotting this.