### PR TITLE
Add UID workaround for IBM i (same as AIX)

### DIFF
--- a/yum/misc.py
+++ b/yum/misc.py
@@ -968,7 +968,7 @@ def _getloginuid():
     #  We might normally call audit.audit_getloginuid(), except that requires
     # importing all of the audit module. And it doesn't work anyway: BZ 518721
     try:
-        if (platform.system() == "AIX"):
+        if (platform.system() == "AIX" or platform.system() == "OS400"):
             fo = os.popen('/usr/bin/id -l -u')
         else:
             fo = open("/proc/self/loginuid")


### PR DESCRIPTION
IBM i (reported as "OS400") needs the same workaround that AIX does, to avoid a read of /proc/self/loginuid