### PR TITLE
yum-ps: Fixed missing output result

### DIFF
--- a/yum/misc.py
+++ b/yum/misc.py
@@ -1053,7 +1053,8 @@ def get_open_files(pid):
         return files
 
     for line in maps:
-        if line.find('fd:') == -1:
+        slash = line.find('/')
+        if slash == -1 or line.find('00:') != -1:
             continue
         line = line.replace('\n', '')
         slash = line.find('/')
@@ -1062,20 +1063,6 @@ def get_open_files(pid):
         filename = filename.strip()
         if filename not in files:
             files.append(filename)
-    
-    cli_f = '/proc/%s/cmdline' % pid
-    try:
-        cli = open(cli_f, 'r')
-    except (IOError, OSError), e:
-        return files
-    
-    cmdline = cli.read()
-    if cmdline.find('\00') != -1:
-        cmds = cmdline.split('\00')
-        for i in cmds:
-            if i.startswith('/'):
-                files.append(i)
-
     return files
 
 def get_uuid(savepath):


### PR DESCRIPTION
Fixed a problem that yum ps output result was lost depending on execution environment.


- In the original code, although it was fixed with "fd:" , the device name may be different.

```
# cat /proc/2475/maps
                                       ↓★★★↓
564e59cd2000-564e59d98000 r-xp 00000000 ca:01 12567                      /usr/sbin/sshd
564e59f97000-564e59f9b000 r--p 000c5000 ca:01 12567                      /usr/sbin/sshd
564e59f9b000-564e59f9c000 rw-p 000c9000 ca:01 12567                      /usr/sbin/sshd
564e59f9c000-564e59fa5000 rw-p 00000000 00:00 0 
564e5a45c000-564e5a47d000 rw-p 00000000 00:00 0                          [heap]
7f09f38f8000-7f09f3904000 r-xp 00000000 ca:01 271911                     /lib64/libnss_files-2.17.so
7f09f3904000-7f09f3b03000 ---p 0000c000 ca:01 271911                     /lib64/libnss_files-2.17.so
```

- In some cases, the contents of cmdline may not be full path.
- First, it is unnecessary because "/ proc /% s / cmdline" content is included in the map.

```
# cat /proc/2568/cmdline 
crond
```