### PR TITLE
Add support to define a smtp port

### DIFF
--- a/etc/yum-cron-hourly.conf
+++ b/etc/yum-cron-hourly.conf
@@ -56,6 +56,9 @@ email_to = root
 # Name of the host to connect to to send email messages.
 email_host = localhost
 
+# Port number to connect to to send email messages.
+email_port = 25
+
 
 [groups]
 # List of groups to update
@@ -63,6 +66,7 @@ group_list = None
 
 # The types of group packages to install
 group_package_types = mandatory, default
+
 
 [base]
 # This section overrides yum.conf

--- a/etc/yum-cron-security.conf
+++ b/etc/yum-cron-security.conf
@@ -59,6 +59,9 @@ email_to = root
 # Name of the host to connect to to send email messages.
 email_host = localhost
 
+# Port number to connect to to send email messages.
+email_port = 25
+
 
 [groups]
 # List of groups to update
@@ -66,6 +69,7 @@ group_list = None
 
 # The types of group packages to install
 group_package_types = mandatory, default
+
 
 [base]
 # This section overrides yum.conf

--- a/etc/yum-cron.conf
+++ b/etc/yum-cron.conf
@@ -58,6 +58,9 @@ email_to = root
 # Name of the host to connect to to send email messages.
 email_host = localhost
 
+# Port number to connect to to send email messages.
+email_port = 25
+
 
 [groups]
 # NOTE: This only works when group_command != objects, which is now the default
@@ -66,6 +69,7 @@ group_list = None
 
 # The types of group packages to install
 group_package_types = mandatory, default
+
 
 [base]
 # This section overrides yum.conf

--- a/yum-cron/yum-cron.py
+++ b/yum-cron/yum-cron.py
@@ -245,11 +245,11 @@ class EmailEmitter(UpdateEmitter):
         # Send the email
         try:
             s = smtplib.SMTP()
-            s.connect(self.opts.email_host)
+            s.connect(self.opts.email_host, self.opts.email_port)
             s.sendmail(self.opts.email_from, self.opts.email_to, msg.as_string())
             s.close()
         except Exception, e:
-            self.logger.error("Failed to send an email to %s: %s" % (self.opts.email_host, e))
+            self.logger.error("Failed to send an email to %s:%s: %s" % (self.opts.email_host, self.opts.email_port, e))
 
 
 class StdIOEmitter(UpdateEmitter):


### PR DESCRIPTION
This is useful if you run a smtp server on a different port than 25.
E.g. 587 or you run a mail-server (exim) on all interfaces on port 25 and postfix for local delivery on port 2525.