### PR TITLE
updateinfo: preload pkgSack. BZ 1528608

### DIFF
--- a/yum/__init__.py
+++ b/yum/__init__.py
@@ -1037,6 +1037,7 @@ class YumBase(depsolve.Depsolve):
             self._upinfo = update_md.UpdateMetadata(logger=logger,
                                                     vlogger=vlogger)
 
+            self.pkgSack  # Preload the sack now, to honor skip_if_unavailable
             for repo in self.repos.listEnabled():
                 if 'updateinfo' not in repo.repoXML.fileTypes():
                     continue


### PR DESCRIPTION
This ensures that we honor the skip_if_unavailable option and disable
unavailable repos when initializing the upinfo object (such as when
running "yum updateinfo" or "yum check-update --security").