### PR TITLE
depsolve: penalize conflicting provider. BZ 1480065

### DIFF
--- a/yum/depsolve.py
+++ b/yum/depsolve.py
@@ -1556,6 +1556,13 @@ class Depsolve(object):
                 continue
             unique_nevra_pkgs[pkg.pkgtup] = pkg
         pkgs = unique_nevra_pkgs.values()
+
+        # Do a conflict filtering; get rid of those pkgs that reqpo conflicts
+        # with
+        if reqpo is not None:
+            pkgs = [pkg for pkg in pkgs
+                        if not any(pkg.checkPrco('provides', conflict)
+                                   for conflict in reqpo.conflicts)]
             
         pkgresults = {}
 


### PR DESCRIPTION
When there are multiple providers available for a requirement, yum would
happily pick the one that the requiring package also has a "Conflicts:"
on (via another virtual provide), failing to resolve the transaction.

Example:
- foo requires bar and conflicts my-bar
- bax provides bar
- bay provides bar, my-bar

Yum might decide to pick bay, only to fail due to the conflict with foo
later in the process.

This commit fixes that by penalizing such a provider so that it's
unlikely for it to be selected during depsolving.