### PR TITLE
Print a disk usage summary on "yum clean all". BZ 1481220

### DIFF
--- a/docs/yum.8
+++ b/docs/yum.8
@@ -1031,11 +1031,37 @@ Or:          \fByum list available 'foo*'\fP
 .IP
 .PP 
 .SH "CLEAN OPTIONS"
-The following are the ways which you can invoke \fByum\fP in clean
-mode. Note that "all files" in the commands below means 
-"all files in currently enabled repositories". 
-If you want to also clean any (temporarily) disabled repositories you need to
-use \fB\-\-enablerepo='*'\fP option.
+The following are the ways which you can invoke \fByum\fP in clean mode.
+
+Note that these commands only operate on files in currently enabled
+repositories.
+If you use substitution variables (such as $releasever) in your \fBcachedir\fP
+configuration, the operation is further restricted to the current values of
+those variables.
+
+For fine-grained control over what is being cleaned, you can use
+\fB\-\-enablerepo\fP, \fB\-\-disablerepo\fP and \fB\-\-releasever\fP as
+desired.
+Note, however, that you cannot use \fB\-\-releasever='*'\fP to do the cleaning
+for all values previously used.
+Also note that untracked (no longer configured) repositories will not be
+automatically cleaned.
+
+To purge the entire cache in one go, the easiest way is to delete the files
+manually.
+Depending on your \fBcachedir\fP configuration, this usually means treating any
+variables as shell wildcards and recursively removing matching directories.
+For example, if your \fBcachedir\fP is /var/cache/yum/$basearch/$releasever,
+then the whole /var/cache/yum directory has to be removed.
+If you do this, \fByum\fP will rebuild the cache as required the next time it
+is run (this may take a while).
+
+As a convenience, when you run \fByum clean all\fP, a recursive lookup will be
+done to detect any repositories not cleaned due to the above restrictions.
+If some are found, a message will be printed stating how much disk space they
+occupy and thus how much you can reclaim by cleaning them.
+If you also supply \fB\-\-verbose\fP, a more detailed breakdown will be
+printed.
 
 .IP "\fByum clean expire-cache\fP"
 Eliminate the local data saying when the metadata and mirrorlists were downloaded for each repo. This means yum will revalidate the cache for each repo. next time it is used. However if the cache is still valid, nothing significant was deleted.

--- a/yum/__init__.py
+++ b/yum/__init__.py
@@ -2890,6 +2890,16 @@ much more problems).
             filelist = misc.getFileList(cachedir, '', [])
         return self._cleanFilelist('rpmdb', filelist)
 
+    def getCachedirGlob(self, dynvar):
+        """Return a glob matching all dirs where yum stores cache files, based
+        on cachedir and the given list of dynamic vars."""
+        yumvar = self.conf.yumvar.copy()
+        for d in dynvar:
+            yumvar[d] = '*'
+        instroot = config.varReplace(self.conf.installroot, self.conf.yumvar)
+        cachedir = config.varReplace(self.conf._pristine_cachedir, yumvar)
+        return (instroot + cachedir).replace('//', '/')
+
     def _cleanFiles(self, exts, pathattr, filetype):
         filelist = []
         for ext in exts:

--- a/yum/config.py
+++ b/yum/config.py
@@ -945,6 +945,9 @@ class YumConf(StartupConf):
 
     _reposlist = []
 
+    # cachedir before variable substitutions
+    _pristine_cachedir = None
+
     def dump(self):
         """Return a string representing the values of all the
         configuration options.
@@ -1146,6 +1149,9 @@ def readMainConfig(startupconf):
     # Read [main] section
     yumconf = YumConf()
     yumconf.populate(startupconf._parser, 'main')
+
+    # Store the original cachedir (for later reference in clean commands)
+    yumconf._pristine_cachedir = yumconf.cachedir
 
     # Apply the installroot to directory options
     def _apply_installroot(yumconf, option):


### PR DESCRIPTION
Replace the confusing "rm -rf" hint with actual info on how much data is
still left behind in the cache.

This commit also removes the "Cleaning up everything" message since
"everything" was often understood by users as "everything ever cached".