### PR TITLE
Gracefully handle "empty" RPM errors. BZ 1690376

### DIFF
--- a/rpmUtils/transaction.py
+++ b/rpmUtils/transaction.py
@@ -119,11 +119,13 @@ class TransactionWrapper:
         tserrors = self.ts.run(cb.callback, '')
         self.ts.setFlags(origflags)
     
+        if tserrors is None:
+            return []
+        if not tserrors:
+            return ['Unknown error during transaction test in RPM']
         reserrors = []
-        if tserrors:
-            for (descr, (etype, mount, need)) in tserrors:
-                reserrors.append(descr)
-        
+        for (descr, (etype, mount, need)) in tserrors:
+            reserrors.append(descr)
         return reserrors
             
         


### PR DESCRIPTION
There are certain cases where RPM returns an empty error list when we
are running a test transaction (such as the issue described in the above
BZ).  Until now, we didn't anticipate that and ended up printing an
ambiguous message saying that the package installation failed which was
immediately followed by "Complete!".

This commit ensures we handle such empty error lists and at least print
a proper error message (which still says "Unknown error" but we can't
get more information from RPM at this point, sadly).

Note that us not doing this check even triggered an RPM segfault but
that was already fixed as BZ 1660232.

Kudos to Panu Matilainen for providing the patch! (I just refactored it
a little bit).