### PR TITLE
Fix local package location xml href

### DIFF
--- a/yum/packages.py
+++ b/yum/packages.py
@@ -2302,7 +2302,7 @@ class YumLocalPackage(YumHeaderPackage):
 
         # if we start seeing fullpaths in the location tag - this is the culprit
         if self._reldir and self.localpath.startswith(self._reldir):
-            relpath = self.localpath.replace(self._reldir, '')
+            relpath = self.localpath.replace(self._reldir, '', 1)
             if relpath[0] == '/': relpath = relpath[1:]
         else:
             relpath = self.localpath


### PR DESCRIPTION
Package remote location is mangled if it's name contains the same as the root directory path. We noticed this when a new package 'reporting-service' was added to our createrepo pipeline and the `location href=` became mangled.

What currently happens:
```
$ mkdir -p /repo/rpms
$ cp ~/reporting-service-0.1.3-1.el7.noarch.rpm /repo/rpms
$ createrepo --pretty --simple-md-filenames /repo
$ zgrep location /repo/repodata/primary.xml.gz
  <location href="rpmsrting-service-0.1.3-1.el7.noarch.rpm"/>
```

After patch:
```
...
$ zgrep location /repo/repodata/primary.xml.gz
  <location href="rpms/reporting-service-0.1.3-1.el7.noarch.rpm"/>
```