### PR TITLE
yum-cron: Add ability to auto restart system if an update requires a restart

### DIFF
--- a/etc/yum-cron-hourly.conf
+++ b/etc/yum-cron-hourly.conf
@@ -20,6 +20,10 @@ download_updates = no
 # the update to be applied
 apply_updates = no
 
+# Whether or not the system should reboot automatically, if yum deems
+# it necessary (`needs-restarting(1)`).
+auto_restart = no
+
 # Maximum amout of time to randomly sleep, in minutes.  The program
 # will sleep for a random amount of time between 0 and random_sleep
 # minutes before running.  This is useful for e.g. staggering the
@@ -48,16 +52,18 @@ output_width = 80
 [email]
 # The address to send email messages from.
 # NOTE: 'localhost' will be replaced with the value of system_name.
-email_from = root
+email_from = root@localhost
 
 # List of addresses to send messages to.
 email_to = root
+# email_cc = nobody
 
 # Name of the host to connect to to send email messages.
 email_host = localhost
 
 
 [groups]
+# NOTE: This only works when group_command != objects, which is now the default
 # List of groups to update
 group_list = None
 

--- a/etc/yum-cron.conf
+++ b/etc/yum-cron.conf
@@ -28,7 +28,9 @@ auto_restart = no
 # minutes before running.  This is useful for e.g. staggering the
 # times that multiple systems will access update servers.  If
 # random_sleep is 0 or negative, the program will run immediately.
-# 6*60 = 360
+#  NOTE that we hold up all the other things in cron.daily as we wait,	# 6*60 = 360
+# so while waiting for 6+ hours is fine for us it might not be nice
+# for logrotate (so wait for 2 hours by default).
 random_sleep = 120
 
 

--- a/etc/yum-cron.conf
+++ b/etc/yum-cron.conf
@@ -6,7 +6,7 @@
 # minimal                            = yum --bugfix update-minimal
 # minimal-security                   = yum --security update-minimal
 # minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
-update_cmd = default
+update_cmd = security
 
 # Whether a message should be emitted when updates are available,
 # were downloaded, or applied.
@@ -17,17 +17,19 @@ download_updates = yes
 
 # Whether updates should be applied when they are available.  Note
 # that download_updates must also be yes for the update to be applied.
-apply_updates = no
+apply_updates = yes
+
+# Whether or not the system should reboot automatically, if yum deems
+# it necessary (`needs-restarting(1)`).
+auto_restart = yes
 
 # Maximum amout of time to randomly sleep, in minutes.  The program
 # will sleep for a random amount of time between 0 and random_sleep
 # minutes before running.  This is useful for e.g. staggering the
 # times that multiple systems will access update servers.  If
 # random_sleep is 0 or negative, the program will run immediately.
-#  NOTE that we hold up all the other things in cron.daily as we wait,
-# so while waiting for 6+ hours is fine for us it might not be nice
-# for logrotate (so wait for 2 hours by default).
-random_sleep = 120
+# 6*60 = 360
+random_sleep = 0
 
 
 [emitters]
@@ -40,7 +42,7 @@ system_name = None
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
 # If emit_via is None or left blank, no messages will be sent.
-emit_via = stdio
+emit_via = email
 
 # The width, in characters, that messages that are emitted should be
 # formatted to.
@@ -53,7 +55,8 @@ output_width = 80
 email_from = root@localhost
 
 # List of addresses to send messages to.
-email_to = root
+email_to = georgeh@apple.com
+email_cc = georgeh@apple.com
 
 # Name of the host to connect to to send email messages.
 email_host = localhost

--- a/etc/yum-cron.conf
+++ b/etc/yum-cron.conf
@@ -28,7 +28,7 @@ auto_restart = no
 # minutes before running.  This is useful for e.g. staggering the
 # times that multiple systems will access update servers.  If
 # random_sleep is 0 or negative, the program will run immediately.
-#  NOTE that we hold up all the other things in cron.daily as we wait,	# 6*60 = 360
+#  NOTE that we hold up all the other things in cron.daily as we wait,
 # so while waiting for 6+ hours is fine for us it might not be nice
 # for logrotate (so wait for 2 hours by default).
 random_sleep = 120

--- a/etc/yum-cron.conf
+++ b/etc/yum-cron.conf
@@ -6,7 +6,7 @@
 # minimal                            = yum --bugfix update-minimal
 # minimal-security                   = yum --security update-minimal
 # minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
-update_cmd = security
+update_cmd = default
 
 # Whether a message should be emitted when updates are available,
 # were downloaded, or applied.
@@ -17,11 +17,11 @@ download_updates = yes
 
 # Whether updates should be applied when they are available.  Note
 # that download_updates must also be yes for the update to be applied.
-apply_updates = yes
+apply_updates = no
 
 # Whether or not the system should reboot automatically, if yum deems
 # it necessary (`needs-restarting(1)`).
-auto_restart = yes
+auto_restart = no
 
 # Maximum amout of time to randomly sleep, in minutes.  The program
 # will sleep for a random amount of time between 0 and random_sleep
@@ -29,7 +29,7 @@ auto_restart = yes
 # times that multiple systems will access update servers.  If
 # random_sleep is 0 or negative, the program will run immediately.
 # 6*60 = 360
-random_sleep = 0
+random_sleep = 120
 
 
 [emitters]
@@ -42,7 +42,7 @@ system_name = None
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
 # If emit_via is None or left blank, no messages will be sent.
-emit_via = email
+emit_via = stdio
 
 # The width, in characters, that messages that are emitted should be
 # formatted to.
@@ -55,8 +55,8 @@ output_width = 80
 email_from = root@localhost
 
 # List of addresses to send messages to.
-email_to = georgeh@apple.com
-email_cc = georgeh@apple.com
+email_to = root
+# email_cc = nobody
 
 # Name of the host to connect to to send email messages.
 email_host = localhost

--- a/yum-cron/yum-cron.py
+++ b/yum-cron/yum-cron.py
@@ -650,6 +650,8 @@ class YumCronBase(yum.YumBase, YumOutput):
         # Acquire the yum lock
         self.acquireLock()
 
+        self.run_with_package_names.add("yum-cron")
+
         # Update the metadata
         self.populateUpdateMetadata()
 


### PR DESCRIPTION
Features added:

* auto restart
Using `needs-restarting`, this PR adds an `auto_restart` option which enables `yum-cron` to schedule a system restart if any update requires a full system restart (NB: excludes process restarts). This means that if, for example, a kernel update requires a restart, users have the ability to let `yum-cron` do this.
* e-mail Cc
Users can specify e-mail addresses to be cc'd into the e-mail notifications