### PR TITLE
Don't reset the package localpath to temporary after download (RhBug:…

### DIFF
--- a/yum/__init__.py
+++ b/yum/__init__.py
@@ -2583,7 +2583,6 @@ much more problems).
                         result, errmsg = self.sigCheckPkg(po)
                         if result != 0:
                             self.verbose_logger.warn("%s", errmsg)
-                    po.localpath = obj.filename
                     if po in errors:
                         del errors[po]
 


### PR DESCRIPTION
…1757613)

The path is already changed from temporary to final earlier in the
function, as the file is renamed. The removed line seems superfluous and
out of place, the value in po.localpath should already be the correct
one.

https://bugzilla.redhat.com/show_bug.cgi?id=1757613

---
I can't really be sure this won't break something elsewhere. I tested the change works on the remote VM against the Spacewalk/Satellite 5 server (as mentioned in the bugzilla), as well as in my RHEL7 container against regular repositories, for both regular package installation and the `--downloadonly` switch.