### PR TITLE
docs:clarify that each repository without enabled=0 is enabled by default

### DIFF
--- a/docs/yum.conf.5
+++ b/docs/yum.conf.5
@@ -1085,7 +1085,7 @@ value of mirrorlist is copied to metalink (if metalink is not set).
 
 .IP
 \fBenabled\fR
-Either `1' or `0'. This tells yum whether or not use this repository.
+Either `1' or `0'. This tells yum whether or not use this repository. Each repository that does not have `enabled=0` is enabled by default.
 
 .IP
 \fBkeepcache\fR


### PR DESCRIPTION
In the man page, it is not mentioned that the repository must not have enabled=1 to work. Vica versa, the enabled string is used to disable a repository.