### PR TITLE
Raise yum-cron-hourly random_sleep to 60m

### DIFF
--- a/etc/yum-cron-hourly.conf
+++ b/etc/yum-cron-hourly.conf
@@ -25,7 +25,7 @@ apply_updates = no
 # minutes before running.  This is useful for e.g. staggering the
 # times that multiple systems will access update servers.  If
 # random_sleep is 0 or negative, the program will run immediately.
-random_sleep = 15
+random_sleep = 60
 
 
 [emitters]


### PR DESCRIPTION
For https://issues.redhat.com/browse/RHEL-40868.

Spreads out the load more on mirror servers.